### PR TITLE
Add timers for the game phase and TNT

### DIFF
--- a/src/main/kotlin/live/adamlearns/animalroyale/AnimalRoyale.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/AnimalRoyale.kt
@@ -8,6 +8,7 @@ import org.bukkit.plugin.java.JavaPlugin
 class AnimalRoyale : JavaPlugin() {
     private var eventListener: EventListener? = null
     private var twitchChat: TwitchChat? = null
+    private var hud: Hud? = null
     private val gameContext = GameContext(this)
 
     private fun setupWorld() {
@@ -35,11 +36,16 @@ class AnimalRoyale : JavaPlugin() {
         this.setupWorld()
         this.setupEventListener()
         this.setupTwitchChat()
+        this.setupHud()
     }
 
     private fun setupTwitchChat() {
         twitchChat = TwitchChat(gameContext)
         gameContext.registerTwitchChat(twitchChat)
+    }
+
+    private fun setupHud() {
+        hud = Hud(gameContext)
     }
 
     override fun onDisable() {

--- a/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
@@ -27,7 +27,7 @@ class Arena(private val gameContext: GameContext) {
     /**
      * This is in ticks.
      */
-    private var timeBetweenTurns = 20 * Ticks.TICKS_PER_SECOND
+    private var timeUntilNextRound = 20 * Ticks.TICKS_PER_SECOND
 
     // This represents the top-center of the arena (since we're looking south).
     private var location: Location? = null
@@ -53,6 +53,12 @@ class Arena(private val gameContext: GameContext) {
     private var suddenDeathTask: BukkitTask? = null
 
     var startingNumSheep: Int = 0
+
+    var currentRoundStartTick: Float = Float.MIN_VALUE
+        private set
+
+    var nextRoundStartTick: Float = Float.MAX_VALUE
+        private set
 
     private val length: Int
         get() = depth * 2
@@ -534,11 +540,15 @@ class Arena(private val gameContext: GameContext) {
         }
 
         startNewMatchTask = Bukkit.getScheduler().runTaskLater(gameContext.javaPlugin, Runnable {
+            val currentTick = gameContext.javaPlugin.server.currentTick.toFloat()
+            currentRoundStartTick = currentTick
+            nextRoundStartTick = currentTick + timeUntilNextRound
+
             gameContext.arena?.startRound()
-            startRoundIn(timeBetweenTurns.toLong())
+            startRoundIn(timeUntilNextRound.toLong())
 
             // The minimum possible turn time is 1 second
-            timeBetweenTurns = max(20.0, floor(timeBetweenTurns * 0.9).toInt().toDouble()).toInt()
+            timeUntilNextRound = max(Ticks.TICKS_PER_SECOND, floor(timeUntilNextRound * 0.9).toInt())
         }, delay)
     }
 

--- a/src/main/kotlin/live/adamlearns/animalroyale/Hud.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Hud.kt
@@ -1,0 +1,127 @@
+package live.adamlearns.animalroyale
+
+import live.adamlearns.animalroyale.ComponentUtils.join
+import live.adamlearns.animalroyale.extensions.cancelIfNeeded
+import live.adamlearns.animalroyale.extensions.clamp
+import net.kyori.adventure.bossbar.BossBar
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.util.Ticks
+import org.bukkit.Bukkit
+import org.bukkit.scheduler.BukkitTask
+
+class Hud(private val gameContext: GameContext) {
+    private val gamePhaseBossBar = BossBar.bossBar(Component.text(), 1f, BossBar.Color.WHITE, BossBar.Overlay.PROGRESS)
+    private val tntBossBar = BossBar.bossBar(Component.text(), 1f, BossBar.Color.RED, BossBar.Overlay.PROGRESS)
+
+    private var updateTntTask: BukkitTask? = null
+
+    private var gamePhase: GamePhase? = null
+    private var gamePhaseStartTick = 0f
+    private var gamePhaseEndTick = 1f
+
+    init {
+        Bukkit.getScheduler()
+            .runTaskTimer(gameContext.javaPlugin, this::updateGamePhaseBar, 0L, PHASE_BAR_UPDATE_PERIOD)
+    }
+
+    private fun updateGamePhaseBar() {
+        showBarToPlayerIfNeeded(gamePhaseBossBar)
+
+        // When we change game phase, we need to set the bar title and reset the progress
+        if (gamePhase != gameContext.gamePhase) {
+            gamePhase = gameContext.gamePhase
+
+            val currentTick = gameContext.javaPlugin.server.currentTick
+            gamePhaseStartTick = currentTick.toFloat()
+            gamePhaseEndTick = (currentTick + getPhaseDuration(gameContext.gamePhase)).toFloat()
+
+            gamePhaseBossBar.name(GamePhaseTitles.getTitle(gameContext.gamePhase))
+            gamePhaseBossBar.progress(1f)
+
+            if (gamePhase == GamePhase.GAMEPLAY) {
+                updateTntTask =
+                    Bukkit.getScheduler()
+                        .runTaskTimer(gameContext.javaPlugin, this::updateTntBar, 0L, TNT_BAR_UPDATE_PERIOD)
+//                showBarToPlayerIfNeeded(tntBossBar)
+            } else {
+                updateTntTask?.cancelIfNeeded()
+//                hideBarFromPlayerIfNeeded(tntBossBar)
+            }
+        }
+
+        // Update the progress
+        if (PHASES_THAT_HAVE_PROGRESS.contains(gamePhase)) {
+            val currentTick = gameContext.javaPlugin.server.currentTick
+            val progress: Float =
+                ((currentTick.toFloat() - gamePhaseStartTick) / (gamePhaseEndTick - gamePhaseStartTick)).clamp(0f, 1f)
+            gamePhaseBossBar.progress(1f - progress) // We want the bar to go 'down' to get the timer effect
+        }
+    }
+
+    private fun updateTntBar() {
+    }
+
+    private fun showBarToPlayerIfNeeded(bar: BossBar) {
+        val player = gameContext.firstPlayer ?: return
+
+        if (!player.activeBossBars().contains(bar)) {
+            player.showBossBar(bar)
+        }
+    }
+
+    private fun hideBarFromPlayerIfNeeded(bar: BossBar) {
+        val player = gameContext.firstPlayer ?: return
+
+        if (player.activeBossBars().contains(bar)) {
+            player.hideBossBar(bar)
+        }
+    }
+
+    companion object {
+        private const val PHASE_BAR_UPDATE_PERIOD: Long = 1L * Ticks.TICKS_PER_SECOND
+        private const val TNT_BAR_UPDATE_PERIOD: Long = 5 // ticks
+
+        private val PHASES_THAT_HAVE_PROGRESS = listOf(GamePhase.LOBBY, GamePhase.LOBBY)
+
+        private fun getPhaseDuration(phase: GamePhase): Int =
+            when (phase) {
+                GamePhase.LOBBY -> Arena.NUM_SECONDS_BEFORE_STARTING_MATCH * Ticks.TICKS_PER_SECOND
+                GamePhase.GAMEPLAY -> Arena.NUM_SECONDS_BEFORE_SUDDEN_DEATH * Ticks.TICKS_PER_SECOND
+                // For other phases, return an arbitrary long timeframe since we do not update the bar during them
+                else -> 3600 * Ticks.TICKS_PER_SECOND
+            }
+    }
+
+    private object GamePhaseTitles {
+        val CREATING_ARENA_TITLE: Component = Component.text("Waiting to start...")
+
+        val LOBBY_TITLE: Component
+            get() = join(
+                " ",
+                Component.text("Game will start soon, type"),
+                Component.text("!join", NamedTextColor.BLUE),
+                Component.text("in chat!"),
+            )
+
+        val PRE_GAMEPLAY_TITLE: Component = Component.text("Starting soon...")
+
+        val GAMEPLAY: Component
+            get() = join(
+                " ",
+                Component.text("Game is ongoing! Waiting for someone to"),
+                Component.text("win", NamedTextColor.GREEN),
+                Component.text("or for"),
+                Component.text("Sudden Death", NamedTextColor.RED),
+                Component.text("to start")
+            )
+
+        fun getTitle(phase: GamePhase): Component =
+            when (phase) {
+                GamePhase.CREATING_ARENA -> CREATING_ARENA_TITLE
+                GamePhase.PRE_GAMEPLAY -> PRE_GAMEPLAY_TITLE
+                GamePhase.LOBBY -> LOBBY_TITLE
+                GamePhase.GAMEPLAY -> GAMEPLAY
+            }
+    }
+}

--- a/src/main/kotlin/live/adamlearns/animalroyale/Hud.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Hud.kt
@@ -93,7 +93,7 @@ class Hud(private val gameContext: GameContext) {
         private const val PHASE_BAR_UPDATE_PERIOD: Long = 1L * Ticks.TICKS_PER_SECOND
         private const val TNT_BAR_UPDATE_PERIOD: Long = Ticks.TICKS_PER_SECOND / 2L
 
-        private val PHASES_THAT_HAVE_PROGRESS = listOf(GamePhase.LOBBY, GamePhase.LOBBY)
+        private val PHASES_THAT_HAVE_PROGRESS = listOf(GamePhase.LOBBY, GamePhase.GAMEPLAY)
 
         private fun getPhaseDuration(phase: GamePhase): Int = when (phase) {
             GamePhase.LOBBY -> Arena.NUM_SECONDS_BEFORE_STARTING_MATCH * Ticks.TICKS_PER_SECOND

--- a/src/main/kotlin/live/adamlearns/animalroyale/Hud.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Hud.kt
@@ -91,7 +91,7 @@ class Hud(private val gameContext: GameContext) {
 
     companion object {
         private const val PHASE_BAR_UPDATE_PERIOD: Long = 1L * Ticks.TICKS_PER_SECOND
-        private const val TNT_BAR_UPDATE_PERIOD: Long = Ticks.TICKS_PER_SECOND / 2L
+        private const val TNT_BAR_UPDATE_PERIOD: Long = Ticks.TICKS_PER_SECOND / 10L
 
         private val PHASES_THAT_HAVE_PROGRESS = listOf(GamePhase.LOBBY, GamePhase.GAMEPLAY)
 

--- a/src/main/kotlin/live/adamlearns/animalroyale/extensions/Float.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/extensions/Float.kt
@@ -1,0 +1,3 @@
+package live.adamlearns.animalroyale.extensions
+
+fun Float.format(digits: Int) = "%.${digits}f".format(this)


### PR DESCRIPTION
## Notes

After our messages in #1 about this, I started looking around into how to implement custom HUDs and whatnot.. And then I saw a picture of someone using the boss bar from Minecraft to display progress for something else! What a revelation.

So here it is for AnimalRoyale. I did two bars:
1. Show info about the 'game phase', basically when the game will start.
2. Show when the next TNT will be launched.

## Demo

> Disclaimer: some sections of the video are at x10 speed.

https://github.com/user-attachments/assets/50eaa99b-6205-4790-a7b3-6372b1dc4fda
