### PR TITLE
Implement !relocate command

### DIFF
--- a/src/main/kotlin/live/adamlearns/animalroyale/TwitchChat.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/TwitchChat.kt
@@ -91,6 +91,7 @@ class TwitchChat(private val gameContext: GameContext) {
             "!addpower" -> onAddPower(senderName, args)
             "!addttl" -> onAddTtl(senderName, args)
             "!join", "!color" -> onJoin(senderName, senderDisplayName, senderChatColor, args)
+            "!relocate" -> onRelocate(senderName, args)
             "!tnt" -> onTnt(senderName, args)
             "!tntcancel", "!tntstop" -> onTntCancel(senderName, args)
         }
@@ -147,6 +148,18 @@ class TwitchChat(private val gameContext: GameContext) {
         Bukkit.getScheduler().runTask(gameContext.javaPlugin) { _ -> sheep.teleport(sheepLocation) }
 
         gamePlayer.setNextTimeAbleToUseSpecialAbility(System.currentTimeMillis() + 15000)
+    }
+
+    private fun onRelocate(senderName: String, args: Array<String>) {
+        // This is only allowed in the 'lobby' (i.e. when players join and before the round starts)
+        if (gameContext.gamePhase != GamePhase.LOBBY) {
+            return
+        }
+
+        val arena = gameContext.arena ?: return
+        val gamePlayer = gameContext.players.getPlayer(senderName) ?: return
+
+        arena.relocateSheepForPlayer(gamePlayer)
     }
 
     private fun onIdentify(senderName: String, args: Array<String>) {


### PR DESCRIPTION
## Notes

This adds a `!relocate` command that will teleport the player's sheep to a new random location. This only works in the lobby.

There are two things I wasn't 100% sure about:
1. Adding a cooldown. I assume it's fine to not have it since the game is not ongoing.
2. Removing the previously created 'safety' block. When a sheep spawns on water, a block is placed below it. When relocating, this block stays behind. I _think_ that's fine? Do we expect players to relocate infinitely to fill water with blocks? 🤣 Would we even care?

## Demo

https://github.com/user-attachments/assets/438d12ef-83b1-4448-84e8-a8fd7038a4ed
