### PR TITLE
Fix error with users that have no chat color

### DIFF
--- a/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
@@ -319,7 +319,7 @@ class Arena(private val gameContext: GameContext) {
      * @param dyeColor
      * @return
      */
-    internal fun createSheepForPlayer(gamePlayer: GamePlayer, dyeColor: DyeColor?): Sheep {
+    internal fun createSheepForPlayer(gamePlayer: GamePlayer, dyeColor: DyeColor): Sheep {
         val world = checkNotNull(gameContext.world)
         val sheepLocation = getNewLocationForSheep()
         val sheep = world.spawnEntity(sheepLocation, EntityType.SHEEP) as Sheep

--- a/src/main/kotlin/live/adamlearns/animalroyale/TwitchChat.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/TwitchChat.kt
@@ -18,6 +18,7 @@ import org.bukkit.entity.Firework
 import org.bukkit.util.Vector
 import java.util.*
 import java.util.concurrent.ThreadLocalRandom
+import java.util.regex.Pattern
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -321,7 +322,10 @@ class TwitchChat(private val gameContext: GameContext) {
 
         try {
             val dyeColor = colorName?.let { DyeColor.valueOf(it) }
-                ?: senderChatColor?.let { getDyeColorFromHex(senderChatColor) }
+                ?: senderChatColor?.trim()
+                    ?.takeIf { isValidHexString(it) }
+                    ?.let { getDyeColorFromHex(senderChatColor) }
+                ?: DyeColor.values().random()
 
             if (gamePlayer.canPlaceSheep) {
                 Bukkit.getScheduler().runTask(gameContext.javaPlugin) { _ ->
@@ -345,7 +349,12 @@ class TwitchChat(private val gameContext: GameContext) {
     companion object {
         val ADMIN_PERMISSIONS = listOf(CommandPermission.OWNER, CommandPermission.BROADCASTER, CommandPermission.MODERATOR)
 
+        private val HEX_PATTERN = Pattern.compile("^#[A-Fa-f0-9]{6}$")
         private var cachedClosestColors: MutableMap<String, DyeColor> = mutableMapOf()
+
+        private fun isValidHexString(hex: String): Boolean {
+            return HEX_PATTERN.matcher(hex).matches()
+        }
 
         private fun getDyeColorFromHex(hex: String): DyeColor =
             // These are the 'default' Twitch colors. For custom colors, we try to find the closest one.


### PR DESCRIPTION
Fixes #16.

## Notes

I didn't realize that `Sheep.color` can't receive a nullable value. Fixed by adding some extra checks to make sure the chat color is valid and choosing a random color when it isn't.

Unfortunately I'm not able to actually test this other than modifying the code to force an invalid color.