### PR TITLE
Fix exception thrown when !relocate was used

### DIFF
--- a/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
@@ -358,10 +358,8 @@ class Arena(private val gameContext: GameContext) {
      * Teleports a sheep to a new random location.
      */
     internal fun relocateSheepForPlayer(gamePlayer: GamePlayer) {
-        val newSheepLocation = getNewLocationForSheep()
-
         Bukkit.getScheduler().runTask(gameContext.javaPlugin) { _ ->
-            gamePlayer.sheep?.teleport(newSheepLocation)
+            gamePlayer.sheep?.teleport(getNewLocationForSheep())
         }
     }
 


### PR DESCRIPTION
Fixes #15.

## Notes

`getNewLocationForSheep` replaces a block in the world to give players a platform, but only when there's water or other 'hazard'. It seems like replacing blocks like that needs to be done in the main thread, and our methods are run asynchronously by default.

Calling it inside `Bukkit.getScheduler().runTask` instead fixes it.