### PR TITLE
Implement simpler `!tnt` controls

### DIFF
--- a/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/Arena.kt
@@ -574,7 +574,7 @@ class Arena(private val gameContext: GameContext) {
     }
 
     companion object {
-        const val MINIMUM_TPS_TO_START = 19.5
+        const val MINIMUM_TPS_TO_START = 18.5
         const val NUM_SECONDS_BEFORE_STARTING_MATCH = 60
         const val NUM_SECONDS_BEFORE_SUDDEN_DEATH = 5 * 60
 

--- a/src/main/kotlin/live/adamlearns/animalroyale/TwitchChat.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/TwitchChat.kt
@@ -9,6 +9,7 @@ import io.github.cdimascio.dotenv.Dotenv
 import live.adamlearns.animalroyale.extensions.distanceTo
 import live.adamlearns.animalroyale.extensions.isAliveAndValid
 import live.adamlearns.animalroyale.extensions.setToCenterOfBlock
+import live.adamlearns.animalroyale.parser.TntCommandParser
 import org.bukkit.Bukkit
 import org.bukkit.Color
 import org.bukkit.DyeColor
@@ -289,25 +290,10 @@ class TwitchChat(private val gameContext: GameContext) {
     }
 
     private fun onTnt(senderName: String, args: Array<String>) {
-        if (args.size < 4) {
-            return
-        }
-
-        try {
-            val yaw = args[0].toInt(10)
-
-            // Minecraft considers -90 to be facing straight up, but most players will probably want to use positive numbers, so we invert this.
-            val pitch = args[1].toInt(10) * -1
-            val distance = args[2].toInt(10)
-            val ttl = args[3].toDouble()
-
-            val gamePlayer = gameContext.players.getPlayer(senderName) ?: return
-
-            gamePlayer.setTntParameters(yaw, pitch, distance, ttl)
-            updateSheepRotationForPlayer(gamePlayer)
-        } catch (e: NumberFormatException) {
-            // Ignore formatting problems since people in Twitch chat will get this wrong quite a lot.
-        }
+        val gamePlayer = gameContext.players.getPlayer(senderName) ?: return
+        val parameters = TntCommandParser.parse(args) ?: return
+        gamePlayer.setTntParameters(parameters.yaw, parameters.pitch, parameters.distance, parameters.ttl)
+        updateSheepRotationForPlayer(gamePlayer)
     }
 
     private fun onJoin(senderName: String, senderDisplayName: String?, senderChatColor: String?, args: Array<String>) {

--- a/src/main/kotlin/live/adamlearns/animalroyale/parser/TntCommandParser.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/parser/TntCommandParser.kt
@@ -88,7 +88,7 @@ object TntCommandParser {
         var distanceWord: String? = null
         var ttlWord: String? = null
 
-        for (arg in args) {
+        for (arg in args.map { it.lowercase() }) {
             if (yawWord == null && YAW_WORDS.containsKey(arg)) {
                 yawWord = arg
             }

--- a/src/main/kotlin/live/adamlearns/animalroyale/parser/TntCommandParser.kt
+++ b/src/main/kotlin/live/adamlearns/animalroyale/parser/TntCommandParser.kt
@@ -1,0 +1,119 @@
+package live.adamlearns.animalroyale.parser
+
+object TntCommandParser {
+    data class Parameters(
+        val yaw: Int,
+        val pitch: Int,
+        val distance: Int,
+        val ttl: Double,
+    )
+
+    private val YAW_WORDS: Map<String, Int> = mapOf(
+        "top" to 0,
+        "right" to 90,
+        "bottom" to 180,
+        "left" to 270,
+        "t" to 0,
+        "r" to 90,
+        "b" to 180,
+        "l" to 270,
+        "north" to 0,
+        "east" to 90,
+        "south" to 180,
+        "west" to 270,
+        "n" to 0,
+        "e" to 90,
+        "s" to 180,
+        "w" to 270,
+        "northeast" to 45,
+        "southeast" to 135,
+        "southwest" to 225,
+        "northwest" to 315,
+        "ne" to 45,
+        "se" to 135,
+        "sw" to 225,
+        "nw" to 315,
+    )
+
+    private const val DEFAULT_PITCH = 45
+    private val PITCH_WORDS: Map<String, Int> = mapOf(
+        "up" to 70,
+        "down" to 20,
+        "u" to 70,
+        "d" to 20,
+    )
+
+    private const val DEFAULT_DISTANCE = 40
+    private val DISTANCE_WORDS: Map<String, Int> = mapOf(
+        "close" to 20,
+        "far" to 60,
+        "veryfar" to 80,
+        "c" to 20,
+        "f" to 60,
+        "v" to 80,
+    )
+
+    private const val DEFAULT_TTL = 2.5
+    private val TTL_WORDS: Map<String, Double> = mapOf(
+        "quick" to 1.0,
+        "slow" to 5.0,
+        "q" to 1.0,
+        "o" to 5.0,
+    )
+
+    fun parse(args: Array<String>): Parameters? = tryParsingRawParameters(args) ?: tryParsingSimpleParameters(args)
+
+    private fun tryParsingRawParameters(args: Array<String>): Parameters? {
+        if (args.size < 4) {
+            return null
+        }
+
+        try {
+            val yaw = args[0].toInt(10)
+
+            // Minecraft considers -90 to be facing straight up, but most players will probably want to use positive numbers, so we invert this.
+            val pitch = args[1].toInt(10) * -1
+            val distance = args[2].toInt(10)
+            val ttl = args[3].toDouble()
+
+            return Parameters(yaw, pitch, distance, ttl)
+        } catch (e: NumberFormatException) {
+            return null
+        }
+    }
+
+    private fun tryParsingSimpleParameters(args: Array<String>): Parameters? {
+        var yawWord: String? = null
+        var pitchWord: String? = null
+        var distanceWord: String? = null
+        var ttlWord: String? = null
+
+        for (arg in args) {
+            if (yawWord == null && YAW_WORDS.containsKey(arg)) {
+                yawWord = arg
+            }
+
+            if (pitchWord == null && PITCH_WORDS.containsKey(arg)) {
+                pitchWord = arg
+            }
+
+            if (distanceWord == null && DISTANCE_WORDS.containsKey(arg)) {
+                distanceWord = arg
+            }
+
+            if (ttlWord == null && TTL_WORDS.containsKey(arg)) {
+                ttlWord = arg
+            }
+        }
+
+        // We need to have a yaw
+        val yaw = YAW_WORDS[yawWord] ?: return null
+
+        // Minecraft considers -90 to be facing straight up, but most players will probably want to use positive numbers, so we invert this.
+        val pitch = -1 * (PITCH_WORDS[pitchWord] ?: DEFAULT_PITCH)
+        val distance = DISTANCE_WORDS[distanceWord] ?: DEFAULT_DISTANCE
+        val ttl = TTL_WORDS[ttlWord] ?: DEFAULT_TTL
+
+        return Parameters(yaw, pitch, distance, ttl)
+    }
+}


### PR DESCRIPTION
## Notes

I'd been wanting to do this for a while, and today felt like a good day to do it.

This implements a new system of parameters for the `!tnt` command. This does not replace the previous system, but rather is a simpler alternative. The best way I can summarize how this work is with this "guide" I made:

<details><summary>Guide</summary>

![Guide](https://github.com/user-attachments/assets/77ae4c82-d284-4154-8eb2-6dd85bc61618)

_(Feel free to add this to [the guide doc](https://docs.google.com/document/d/1moUj-t_0jbqze7Hj56434eO6iMPjn2eO_aeHCuQcwMw/edit?tab=t.0#heading=h.8z08al4wzmpi).)_

</details> 

Basically, the parameters are the same. What changes is:

- Only `yaw` is required in the command. Everything else has a default value if not specified.
- The parameters have _simpler_ values:
  - `yaw` can be specified with:
    - Relative directions (`top`/`right`/`bottom`/`left`) and shorthands (`t`/`r`/`b`/`l`).
    - Cardinal directions (e.g. `north`, `southwest`) and shorthands (e.g. `n`, `sw`).
  - `pitch` with `up`/`down` (and `u`/`d`).
  - `power` with `close`/`far`/`veryfar` (`c`/`f`/`v`).
  - `ttl` with `quick`/`slow` (`q`/`o`).
- The parameters can be specified in any order (since the words and shorthands are all different, we don't care in which order they appear; if there are multiple for the same parameter, we'll only take the first one).

Overall this makes the command easier to use, and it makes it harder to write it in an invalid way.

---

Besides this change, I also updated the required TPS for the game to start. It seems like the `/tps` command only updates once per minute, so it can take up to that much for the game to start even if the server is already performing well. Based on some quick testing, `18.5` seems to be a good value for this.

## Demo

Recorded a demo with some examples:

https://github.com/user-attachments/assets/fbb4082d-caa3-4b44-b866-888914a11fca
